### PR TITLE
Use only active session in getRandomSongByPreferences, not inactive ones...

### DIFF
--- a/jukebox/jukebox_core/api.py
+++ b/jukebox/jukebox_core/api.py
@@ -377,7 +377,7 @@ class songs(api_base):
 
         # get logged in users
         sessions = Session.objects.exclude(
-            expire_date__gt=datetime.today()
+            expire_date__lt=datetime.today()
         )
         for session in sessions.all():
             data = session.get_decoded()


### PR DESCRIPTION
When the queue is empty, getRandomSongByPreferences is used for determining which song to play, based on sessions.

Before it did only consider expired sessions (expire-date > now), this changes the condition to only consider open sessions.

Before it did result in timeouts (e.g. icecast timeout) when many sessions are in the database.
