### PR TITLE
Handle expections, such as timeout, when streaming to icecast.

### DIFF
--- a/jukebox/jukebox_shout/management/commands/jukebox_shout.py
+++ b/jukebox/jukebox_shout/management/commands/jukebox_shout.py
@@ -165,7 +165,11 @@ class Command(BaseCommand):
                 buf = f.read(4096)
                 if not len(buf):
                     break
-                self.shout.send(buf)
+                try:
+                    self.shout.send(buf)
+                except shout.ShoutException, exc:
+                    print "Error: " + str(exc)
+                    break
                 self.shout.sync()
         f.close()
 


### PR DESCRIPTION
When an error occurs while streaming it is now handled so that the shout streamer does not crash any more.
For example when the icecast fires a timeout it used to crash (see also #18).
