### PR TITLE
Update views.py

### DIFF
--- a/jukebox/jukebox_core/views.py
+++ b/jukebox/jukebox_core/views.py
@@ -110,7 +110,7 @@ class songs_skip(JukeboxAPIView):
 
         songs_api = api.songs()
         songs_api.skipCurrentSong()
-
+        return Response("")
 
 class artists(JukeboxAPIView):
     permissions = (IsAuthenticated, )


### PR DESCRIPTION
Return empty response to fix django-rest-framework 
TypeError at /api/v1/songs/skip
'NoneType' object does not support item assignment
